### PR TITLE
Include missing files in the distribution manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,5 @@ include vendor/duktape.h
 include vendor/duktape.c
 include vendor/duk_module_duktape.c
 include vendor/duk_module_duktape.h
+include vendor/duk_print_alert.c
+include vendor/duk_print_alert.h


### PR DESCRIPTION
After 0.4.0 was released, "pip install pyduktape2" is no longer working.
```
 running bdist_wheel
  running build
  running build_ext
  cythoning pyduktape2.pyx to pyduktape2.c
  /home/ash/PycharmProjects/p1/.venv/lib/python3.6/site-packages/Cython/Compiler/Main.py:369: FutureWarning: Cython directive 'language_level' not set, using 2 for now (Py2). This will change in a later release! File: /tmp/pip-install-d_6b_6jz/pyduktape2/pyduktape2.pyx
    tree = Parsing.p_module(s, pxd, full_module_name)
  warning: pyduktape2.pyx:112:4: 'duk_uint_t' redeclared
  building 'pyduktape2' extension
  creating build
  creating build/temp.linux-x86_64-3.6
  x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fdebug-prefix-map=/build/python3.6-yK1u7P/python3.6-3.6.12=. -specs=/usr/share/dpkg/no-pie-compile.specs -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/home/ash/PycharmProjects/p1/.venv/include -I/usr/include/python3.6m -c pyduktape2.c -o build/temp.linux-x86_64-3.6/pyduktape2.o
  pyduktape2.c:610:10: fatal error: vendor/duk_print_alert.c: No such file or directory
    610 | #include "vendor/duk_print_alert.c"
        |          ^~~~~~~~~~~~~~~~~~~~~~~~~~
  compilation terminated.
  error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
  ----------------------------------------
  ERROR: Failed building wheel for pyduktape2
  Running setup.py clean for pyduktape2
Failed to build pyduktape2
Installing collected packages: pyduktape2
  Attempting uninstall: pyduktape2
    Found existing installation: pyduktape2 0.3.1
    Uninstalling pyduktape2-0.3.1:
      Successfully uninstalled pyduktape2-0.3.1
    Running setup.py install for pyduktape2 ... error
    ERROR: Command errored out with exit status 1:
     command: /home/ash/PycharmProjects/p1/.venv/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-d_6b_6jz/pyduktape2/setup.py'"'"'; __file__='"'"'/tmp/pip-install-d_6b_6jz/pyduktape2/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-_l_dcmaw/install-record.txt --single-version-externally-managed --compile --install-headers /home/ash/PycharmProjects/p1/.venv/include/site/python3.6/pyduktape2
```

Adding these two new files in the manifest fixes it (hopefully).
Fixes #3