### PR TITLE
build: limit Cython version to pre-3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,9 @@ setup(
         'Topic :: Software Development :: Interpreters',
     ],
     packages=find_packages(exclude=['tests']),
-    setup_requires=['setuptools>=18.0', 'Cython'],
+    setup_requires=['setuptools>=18.0', 'Cython<3'],
     test_suite='tests',
-    install_requires=['Cython'],
+    install_requires=['Cython<3'],
     ext_modules=extensions,
     include_package_data=True,
     zip_safe=False


### PR DESCRIPTION
Building with Cython 3 fails (see
<https://github.com/phith0n/pyduktape2/issues/14>). This change restricts the versions of Cython to pre-3.0.0 so that users can install the package without having to manually restrict Cython to the right versions.